### PR TITLE
Graceful Failure When Freshness Cannot Be Calculated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.0.17 (6/11/2023) 
 
 - Fix `Last-Modified` validation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix `Last-Modified` validation.
+
 ## 0.0.16 (25/10/2023) 
 
 - Add `install_cache` function. (#95)

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+hishel.com

--- a/hishel/__init__.py
+++ b/hishel/__init__.py
@@ -13,4 +13,4 @@ def install_cache() -> None:  # pragma: no cover
     httpx.Client = CacheClient  # type: ignore
 
 
-__version__ = "0.0.16"
+__version__ = "0.0.17"

--- a/hishel/_controller.py
+++ b/hishel/_controller.py
@@ -231,7 +231,7 @@ class Controller:
 
         precondition_headers: tp.List[tp.Tuple[bytes, bytes]] = []
         if last_modified:
-            precondition_headers.append((b"If-Unmodified-Since", last_modified))
+            precondition_headers.append((b"If-Modified-Since", last_modified))
         if etag:
             precondition_headers.append((b"If-None-Match", etag))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ types-redis==4.6.0.7
 trio==0.22.2
 coverage==7.3.0
 types-PyYAML==6.0.12.11
-typing_extensions==4.7.1
+typing_extensions==4.8.0
 
 # build
 hatch==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -e .[yaml,redis,sqlite]
 
 # linting
-ruff==0.0.291
+ruff==0.1.3
 mypy==1.5.1
 black==23.7.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ pytest==7.4.3
 pytest-asyncio==0.21.1
 types-redis==4.6.0.7
 trio==0.22.2
-coverage==7.3.0
+coverage==7.3.2
 types-PyYAML==6.0.12.12
 typing_extensions==4.8.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ pytest-asyncio==0.21.1
 types-redis==4.6.0.7
 trio==0.22.2
 coverage==7.3.0
-types-PyYAML==6.0.12.11
+types-PyYAML==6.0.12.12
 typing_extensions==4.8.0
 
 # build

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ mkdocs-material==9.2.0
 mkdocstrings[python]==0.23.0
 
 # tests
-pytest==7.4.2
+pytest==7.4.3
 pytest-asyncio==0.21.1
 types-redis==4.6.0.7
 trio==0.22.2

--- a/tests/_async/test_storages.py
+++ b/tests/_async/test_storages.py
@@ -116,7 +116,7 @@ async def test_filestorage_expired():
         first_key, response=response, request=first_request, metadata=dummy_metadata
     )
 
-    await asleep(1)
+    await asleep(2)
     await storage.store(
         second_key, response=response, request=second_request, metadata=dummy_metadata
     )
@@ -142,7 +142,7 @@ async def test_redisstorage_expired():
         first_key, response=response, request=first_request, metadata=dummy_metadata
     )
 
-    await asleep(1)
+    await asleep(2)
     await storage.store(
         second_key, response=response, request=second_request, metadata=dummy_metadata
     )
@@ -166,7 +166,7 @@ async def test_sqlite_expired():
         first_key, response=response, request=first_request, metadata=dummy_metadata
     )
 
-    await asleep(1)
+    await asleep(2)
     await storage.store(
         second_key, response=response, request=second_request, metadata=dummy_metadata
     )

--- a/tests/_sync/test_storages.py
+++ b/tests/_sync/test_storages.py
@@ -116,7 +116,7 @@ def test_filestorage_expired():
         first_key, response=response, request=first_request, metadata=dummy_metadata
     )
 
-    sleep(1)
+    sleep(2)
     storage.store(
         second_key, response=response, request=second_request, metadata=dummy_metadata
     )
@@ -142,7 +142,7 @@ def test_redisstorage_expired():
         first_key, response=response, request=first_request, metadata=dummy_metadata
     )
 
-    sleep(1)
+    sleep(2)
     storage.store(
         second_key, response=response, request=second_request, metadata=dummy_metadata
     )
@@ -166,7 +166,7 @@ def test_sqlite_expired():
         first_key, response=response, request=first_request, metadata=dummy_metadata
     )
 
-    sleep(1)
+    sleep(2)
     storage.store(
         second_key, response=response, request=second_request, metadata=dummy_metadata
     )

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -229,7 +229,7 @@ def test_make_conditional_request_with_last_modified():
 
     assert request.headers == [
         (b"Content-Type", b"application/json"),
-        (b"If-Unmodified-Since", b"Wed, 21 Oct 2015 07:28:00 GMT"),
+        (b"If-Modified-Since", b"Wed, 21 Oct 2015 07:28:00 GMT"),
     ]
 
 


### PR DESCRIPTION
In the controller logic, there is a RuntimeError that is raised if the library cannot calculate the freshness for a request. This PR changes that behavior to run a conditional request in that circumstance, rather than fail out. 